### PR TITLE
Dev

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,6 +10,9 @@
     %sveltekit.head%
   </head>
   <style>
+    html {
+        overflow-x: hidden;
+    }
     body {
         max-width: 100vw;
         overflow-x: hidden;

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -329,6 +329,11 @@ export class App {
         return _.merge({}, DEFAULT_CONFIG, this.config);
     }
     
+    async resetConfigToDefault(): Promise<void> {
+        this.config = _.cloneDeep(DEFAULT_CONFIG);
+        await this.save();
+    }
+    
     async saveConfig(config: WenbunConfig): Promise<void> {
         this.config = config;
         await this.save();

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -70,6 +70,9 @@ export interface WenbunConfig {
     newPreviouslyStudiedCardPerDay?: number;
     newPreviouslyStudiedCardOrder?: NewCardOrder;
     
+    // Review
+    gradingMethod?: 'auto' | 'manual';
+    
     // FSRS
     learningSteps?: FSRS.Steps;
     previouslyStudiedLearningSteps?: FSRS.Steps;
@@ -95,10 +98,12 @@ const DEFAULT_CONFIG: DeepRequired<WenbunConfig> = {
     newPreviouslyStudiedCardPerDay: 20,
     newPreviouslyStudiedCardOrder: NewCardOrder.Mix,
     
+    gradingMethod: 'manual',
+    
     learningSteps: ["1m", "10m"],
     previouslyStudiedLearningSteps: ["1m", "5d"],
     desiredRetention: 0.9,
-    enableShortTerm: true,
+    enableShortTerm: false,
     enableFuzz: false,
     FSRSParams: DEFAULT_FSRS_PARAM,
     
@@ -168,6 +173,7 @@ export class App {
     async init(): Promise<void> {
         await this.load();
         this.extraStudyHandler.init();
+        this.updateFSRS();
         if (this.isNeedToProcessTodaySchedule()) {
             await this.processTodaySchedule();
         }
@@ -176,6 +182,8 @@ export class App {
     async debug() {
         this.decks = ['test'];
         this.deckData = {};
+        this.reviewLogs = [];
+        this.config = DEFAULT_CONFIG;
         await this.ensureDeckData();
         await this.save();
     }
@@ -641,5 +649,9 @@ export class App {
             ignored: p.ignoredCount / p.totalCount * 100,
             rest: (p.totalCount - p.youngCount - p.matureCount - p.previouslyStudiedCount - p.ignoredCount) / p.totalCount * 100,
         }
+    }
+    
+    isAutoGrading(): boolean {
+        return this.getConfig().gradingMethod === 'auto';
     }
 }

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -98,7 +98,7 @@ const DEFAULT_CONFIG: DeepRequired<WenbunConfig> = {
     newPreviouslyStudiedCardPerDay: 20,
     newPreviouslyStudiedCardOrder: NewCardOrder.Mix,
     
-    gradingMethod: 'manual',
+    gradingMethod: 'auto',
     
     learningSteps: ["1m", "10m"],
     previouslyStudiedLearningSteps: ["1m", "5d"],

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -422,6 +422,9 @@ export class App {
     getMaxWarmUpCount(): number {
         return DEFAULT_WARMUP_MAX_COUNT;
     }
+    isWarmUpCard(deckId: string, cardId: number): boolean {
+        return this.getWarmUpCount(deckId, cardId) !== undefined;
+    }
     
     getNewOrWarmUpCard(deckId: string): number {
         const newCard = this.getNewCard(deckId);
@@ -496,6 +499,7 @@ export class App {
         return this.getCard(deckId, cardId)?.due;
     }
     getCardDueFormatted(deckId: string, cardId: number): string {
+        if (this.isWarmUpCard(deckId, cardId)) return 'Warm Up';
         const due = this.getCardDue(deckId, cardId);
         if (!due) return 'Not Started';
         return dateDiffFormatted(new Date(), new Date(due));

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -453,7 +453,11 @@ export class App {
         
         const newCardLength = this.getNewCardsCount(deckId);
         const warmUpCardLength = warmUpIds.length;
-        // randomy chose between new card and warm up card proportional to the number of the cards
+        // randomly choose between new card and warm up card proportional to the number of the cards
+        if (newCardLength + warmUpCardLength === 0) {
+            // No cards available, return a sentinel value (e.g., -1)
+            return -1;
+        }
         return Math.random() < newCardLength / (newCardLength + warmUpCardLength) ?
             newCard : warmUpId;
     }

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -622,10 +622,18 @@ export class App {
         const tomorrow = today + 1;
         const todaysCards = Object.entries(deckData.schedule).filter(([id, s]) => {
             const isIgnored = !!deckData.ignoredIds?.includes(+id);
+            if (isIgnored) return false;
+            
             const due = getDaysSinceEpochLocal(new Date(s.due));
-            return due <= tomorrow && !isIgnored;
+            //TODO: make sure this is correct
+            if (s.state === FSRS.State.Review) {
+                // for review cards, use date
+                return due < tomorrow;
+            } else {
+                // learning and relearning cards is always valid
+                return true;
+            }
         });
-        // TODO: for learning cards, use exact time; for review cards, use date
         // sort by time
         todaysCards.sort((a, b) => new Date(a[1].due).getTime() - new Date(b[1].due).getTime());
         return todaysCards.map((s) => +s[0]);

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -14,6 +14,7 @@ const STORE_KEY_DECKS = "decks"
 const STORE_KEY_DECK_DATA = "deckData"
 const STORE_KEY_CONFIG = "config"
 const STORE_KEY_REVIEW_LOGS = "reviewLogs"
+const STORE_KEY_AUTO_REVIEW_GRADE_LOG = "autoReviewGradeLog"
 
 const FSRS_GRADES: FSRS.Grade[] = [FSRS.Rating.Again, FSRS.Rating.Hard, FSRS.Rating.Good, FSRS.Rating.Easy];
 export const DEFAULT_GROUP_CONTENT_COUNT = 30;
@@ -125,11 +126,18 @@ type ReviewLog = {
     log: FSRS.ReviewLog;
 }
 
+type AutoReviewGradeLog = {
+    correctCount: number;
+    mistakeCount: number;
+    grade: FSRS.Grade;
+}
+
 export class App {
     decks: string[] = [];
     deckData: Record<string, DeckData> = {};
     config: WenbunConfig = DEFAULT_CONFIG;
     reviewLogs: ReviewLog[] = [];
+    autoReviewGradeLog: AutoReviewGradeLog[] = [];
     isLoadDone = false;
     fsrs!: FSRS.FSRS;
     fsrsPrevStudied!: FSRS.FSRS;
@@ -192,16 +200,18 @@ export class App {
     }
     
     async load() {
-        const [decks, deckData, config, reviewLogs] = await Promise.all([
+        const [decks, deckData, config, reviewLogs, autoReviewGradeLog] = await Promise.all([
             this.storage.load<string[]>(STORE_KEY_DECKS),
             this.storage.load<Record<string, DeckData>>(STORE_KEY_DECK_DATA),
             this.storage.load<WenbunConfig>(STORE_KEY_CONFIG),
             this.storage.load<ReviewLog[]>(STORE_KEY_REVIEW_LOGS),
+            this.storage.load<AutoReviewGradeLog[]>(STORE_KEY_AUTO_REVIEW_GRADE_LOG),
         ]);
         this.decks = decks || [];
         this.deckData = deckData || {};
         this.config = config || DEFAULT_CONFIG;
         this.reviewLogs = reviewLogs || [];
+        this.autoReviewGradeLog = autoReviewGradeLog || [];
         this.isLoadDone = true;
     }
     async save() {
@@ -210,6 +220,7 @@ export class App {
             this.storage.save(STORE_KEY_DECK_DATA, this.deckData),
             this.storage.save(STORE_KEY_CONFIG, this.config),
             this.storage.save(STORE_KEY_REVIEW_LOGS, this.reviewLogs),
+            this.storage.save(STORE_KEY_AUTO_REVIEW_GRADE_LOG, this.autoReviewGradeLog),
         ]);
     }
     
@@ -723,5 +734,9 @@ export class App {
     
     isAutoGrading(): boolean {
         return this.getConfig().gradingMethod === 'auto';
+    }
+    
+    storeAutoGradeLog(correctCount: number, mistakeCount: number, grade: FSRS.Grade) {
+        this.autoReviewGradeLog.push({correctCount, mistakeCount, grade});
     }
 }

--- a/src/lib/autoReview.ts
+++ b/src/lib/autoReview.ts
@@ -31,9 +31,9 @@ export namespace AutoReview {
     export function getGrade(data: AutoReviewData): FSRS.Grade {
         const mistakeRate = data.incorrectStrokeCount / data.totalStrokeCount;
         // for automatic review, never rate as easy
-        if (mistakeRate < 0.25 || data.incorrectStrokeCount <= 4) {
+        if (mistakeRate < 0.25 || data.incorrectStrokeCount <= 2) {
             return FSRS.Rating.Good;
-        } else if (mistakeRate < 0.5 || data.incorrectStrokeCount <= 6) {
+        } else if (mistakeRate < 0.5 || data.incorrectStrokeCount <= 4) {
             return FSRS.Rating.Hard;
         } else {
             return FSRS.Rating.Again;

--- a/src/lib/autoReview.ts
+++ b/src/lib/autoReview.ts
@@ -29,7 +29,9 @@ export const AutoReviewGradeFAClass: Record<FSRS.Grade, string> = {
 
 export namespace AutoReview {
     export function getGrade(data: AutoReviewData): FSRS.Grade {
-        const mistakeRate = data.incorrectStrokeCount / data.correctStrokeCount;
+        const mistakeRate = data.correctStrokeCount === 0
+            ? Infinity
+            : data.incorrectStrokeCount / data.correctStrokeCount;
         // for automatic review, never rate as easy
         if (mistakeRate < 0.25 || data.incorrectStrokeCount <= 2) {
             return FSRS.Rating.Good;

--- a/src/lib/autoReview.ts
+++ b/src/lib/autoReview.ts
@@ -33,7 +33,7 @@ export namespace AutoReview {
         // for automatic review, never rate as easy
         if (mistakeRate < 0.25 || data.incorrectStrokeCount <= 2) {
             return FSRS.Rating.Good;
-        } else if (mistakeRate < 0.5 || data.incorrectStrokeCount <= 4) {
+        } else if (mistakeRate < 0.75 || data.incorrectStrokeCount <= 4) {
             return FSRS.Rating.Hard;
         } else {
             return FSRS.Rating.Again;

--- a/src/lib/autoReview.ts
+++ b/src/lib/autoReview.ts
@@ -1,0 +1,51 @@
+import * as FSRS from "ts-fsrs"
+
+export interface AutoReviewData {
+    correctStrokeCount: number;
+    incorrectStrokeCount: number;
+    totalStrokeCount: number;
+}
+
+export const AutoReviewGradeLabel: Record<FSRS.Grade, string> = {
+    [FSRS.Rating.Again]: "Fail",
+    [FSRS.Rating.Hard]: "Hard",
+    [FSRS.Rating.Good]: "Good",
+    [FSRS.Rating.Easy]: "",
+}
+
+export const AutoReviewGradeClass: Record<FSRS.Grade, string> = {
+    [FSRS.Rating.Again]: "again",
+    [FSRS.Rating.Hard]: "hard",
+    [FSRS.Rating.Good]: "good",
+    [FSRS.Rating.Easy]: "",
+}
+
+export const AutoReviewGradeFAClass: Record<FSRS.Grade, string> = {
+    [FSRS.Rating.Again]: "fa fa-solid fa-face-frown",
+    [FSRS.Rating.Hard]: "fa fa-solid fa-face-meh",
+    [FSRS.Rating.Good]: "fa fa-solid fa-face-smile",
+    [FSRS.Rating.Easy]: "",
+}
+
+export namespace AutoReview {
+    export function getGrade(data: AutoReviewData): FSRS.Grade {
+        const mistakeRate = data.incorrectStrokeCount / data.totalStrokeCount;
+        // for automatic review, never rate as easy
+        if (mistakeRate < 0.25 || data.incorrectStrokeCount <= 4) {
+            return FSRS.Rating.Good;
+        } else if (mistakeRate < 0.5 || data.incorrectStrokeCount <= 6) {
+            return FSRS.Rating.Hard;
+        } else {
+            return FSRS.Rating.Again;
+        }
+    }
+    
+    export function gradeToLabel(grade: FSRS.Grade): string {
+        switch (grade) {
+            case FSRS.Rating.Again: return "Again";
+            case FSRS.Rating.Hard: return "Hard";
+            case FSRS.Rating.Good: return "Good";
+            default: return "Unknown";
+        }
+    }
+}

--- a/src/lib/autoReview.ts
+++ b/src/lib/autoReview.ts
@@ -10,21 +10,21 @@ export const AutoReviewGradeLabel: Record<FSRS.Grade, string> = {
     [FSRS.Rating.Again]: "Fail",
     [FSRS.Rating.Hard]: "Hard",
     [FSRS.Rating.Good]: "Good",
-    [FSRS.Rating.Easy]: "",
+    [FSRS.Rating.Easy]: "Easy",
 }
 
 export const AutoReviewGradeClass: Record<FSRS.Grade, string> = {
     [FSRS.Rating.Again]: "again",
     [FSRS.Rating.Hard]: "hard",
     [FSRS.Rating.Good]: "good",
-    [FSRS.Rating.Easy]: "",
+    [FSRS.Rating.Easy]: "easy",
 }
 
 export const AutoReviewGradeFAClass: Record<FSRS.Grade, string> = {
     [FSRS.Rating.Again]: "fa fa-solid fa-face-frown",
     [FSRS.Rating.Hard]: "fa fa-solid fa-face-meh",
     [FSRS.Rating.Good]: "fa fa-solid fa-face-smile",
-    [FSRS.Rating.Easy]: "",
+    [FSRS.Rating.Easy]: "fa fa-solid fa-star",
 }
 
 export namespace AutoReview {

--- a/src/lib/autoReview.ts
+++ b/src/lib/autoReview.ts
@@ -29,7 +29,7 @@ export const AutoReviewGradeFAClass: Record<FSRS.Grade, string> = {
 
 export namespace AutoReview {
     export function getGrade(data: AutoReviewData): FSRS.Grade {
-        const mistakeRate = data.incorrectStrokeCount / data.totalStrokeCount;
+        const mistakeRate = data.incorrectStrokeCount / data.correctStrokeCount;
         // for automatic review, never rate as easy
         if (mistakeRate < 0.25 || data.incorrectStrokeCount <= 2) {
             return FSRS.Rating.Good;

--- a/src/lib/components/CharacterWriter.svelte
+++ b/src/lib/components/CharacterWriter.svelte
@@ -270,9 +270,6 @@
             visibility: hidden;
         }
     }
-    /*.new-element-indicator.is-complete {
-      --p: var(--next-progress, 100%);
-    }*/
     .auto-review-indicator-container {
         all: unset;
         cursor: pointer;

--- a/src/lib/components/CharacterWriter.svelte
+++ b/src/lib/components/CharacterWriter.svelte
@@ -153,7 +153,7 @@
     
     function toggleRequestManualGrade() {
         if (cardConfig.isWarmUp) {
-            window.alert("Can't change grade during warm up. As grade is not used for scheduling during warm up.");
+            window.alert("Can't change grade during warm-up, since grading doesn't affect scheduling in this phase.");
             return;
         }
         isRequestManualGrade = !isRequestManualGrade;

--- a/src/lib/components/CharacterWriter.svelte
+++ b/src/lib/components/CharacterWriter.svelte
@@ -20,12 +20,6 @@
     let isStopPlayAudio = $state(false); // so we know to play audio only once
     let unmounted = $state(false);
     
-    let autoReviewData: AutoReviewData  = $state({
-        correctStrokeCount: 0,
-        incorrectStrokeCount: 0,
-        totalStrokeCount: 0,
-    });
-
     function getEmInPx(): number {
         return parseFloat(getComputedStyle(document.documentElement).fontSize);
     }
@@ -41,11 +35,13 @@
 		characterData: CharacterWriterData | undefined;
 		cardConfig: CharacterWriterConfig;
 		autoGrade: FSRS.Grade | undefined;
+		autoReviewData: AutoReviewData;
 		app: App
 	}
     let { 
         onComplete, isRequestManualGrade = $bindable(), 
-        characterData, app, cardConfig, autoGrade 
+        characterData, app, cardConfig, autoGrade,
+        autoReviewData = $bindable()
     }: Props = $props();
     
     let completedCharCount: number = $state(0);
@@ -167,6 +163,11 @@
     }
     
     onMount(() => {
+        autoReviewData = {
+            correctStrokeCount: 0,
+            incorrectStrokeCount: 0,
+            totalStrokeCount: 0,
+        };
         updateWidth();
         setupAudios();
         window.addEventListener('resize', updateWidth);

--- a/src/lib/components/CharacterWriter.svelte
+++ b/src/lib/components/CharacterWriter.svelte
@@ -15,6 +15,7 @@
     const correctSound = new Audio(`${base}/assets/sounds/correct-choice-43861.mp3`);
     let audios: AudioSequence[] = $state([]);
     let isComplete = $state(false);
+    let isStopPlayAudio = $state(false); // so we know to play audio only once
     let unmounted = $state(false);
 
     function getEmInPx(): number {
@@ -45,6 +46,7 @@
         }
     }
     function completeChar() {
+        isStopPlayAudio = true;
         if (unmounted) return;
         if (cardConfig.isFirstTime) {
             completedCharCount = (completedCharCount + 1) % characterData!.characters.length;
@@ -94,7 +96,7 @@
             writer.quiz();
         } else {
             setTimeout(() => {
-                playAudio();
+                if (!isStopPlayAudio) playAudio();
             }, NEXT_CHAR_DELAY);
             setTimeout(() => {
                 writer.animateCharacter({

--- a/src/lib/components/CharacterWriter.svelte
+++ b/src/lib/components/CharacterWriter.svelte
@@ -136,7 +136,6 @@
     
     function setupAudios() {
         const urls = characterData?.audioUrl;
-        console.log(urls);
         if (!urls) return;
         audios = urls.map(rawUs => {
             const us = rawUs.map(u => getAudioUrl(cardConfig.lang, u));

--- a/src/lib/components/CharacterWriter.svelte
+++ b/src/lib/components/CharacterWriter.svelte
@@ -37,14 +37,14 @@
     
     interface Props {
 		onComplete: (data: AutoReviewData) => void;
-		onRequestManualGrade: () => void;
+		isRequestManualGrade: boolean;
 		characterData: CharacterWriterData | undefined;
 		cardConfig: CharacterWriterConfig;
 		autoGrade: FSRS.Grade | undefined;
 		app: App
 	}
     let { 
-        onComplete, onRequestManualGrade, 
+        onComplete, isRequestManualGrade = $bindable(), 
         characterData, app, cardConfig, autoGrade 
     }: Props = $props();
     
@@ -148,6 +148,10 @@
         const a = audios[index];
         a.stop();
         a.play();
+    }
+    
+    function toggleRequestManualGrade() {
+        isRequestManualGrade = !isRequestManualGrade;
     }
     
     onMount(() => {
@@ -263,9 +267,35 @@
             font-size: 3em;
         }
         &:hover { opacity: 0.8; }
+        &.easy { --color: #3E92CC;}
         &.good { --color: #419E6F;}
         &.hard { --color: #DA8C22;}
         &.again { --color: #DB6B6C;}
+        &.blinking {
+            animation: blinking 1s ease-in-out infinite;
+        }
+        &.echo-once::after {
+            content: "";
+            position: absolute;
+            inset: -6px;
+            border-radius: 50%;
+            border: 6px solid var(--color);
+            opacity: 0;
+            transform: scale(1);
+            z-index: -1;
+            animation: ring 1.6s ease-out 1;
+        }
+    }
+    @keyframes blinking {
+        0%   { opacity: 1; }
+        50%  { opacity: 0.6; }
+        100% { opacity: 1; }
+    }
+    @keyframes ring {
+        0%   { transform: scale(1);   opacity: 0; }
+        1%   { transform: scale(1);   opacity: 0.6; }
+        70%  { transform: scale(1.6); opacity: 0;   }
+        100% { transform: scale(1.6); opacity: 0;   }
     }
 </style>
 
@@ -309,7 +339,10 @@
         {#if autoGrade}
             <button 
                 class={`auto-review-indicator-container ${AutoReviewGradeClass[autoGrade]}`}
-                onclick={() => onRequestManualGrade()}
+                class:blinking={isRequestManualGrade}
+                class:animated={isRequestManualGrade}
+                class:echo-once={!isRequestManualGrade}
+                onclick={() => toggleRequestManualGrade()}
             >
                 <i class={AutoReviewGradeFAClass[autoGrade]}></i>
                 <span>{AutoReviewGradeLabel[autoGrade]}</span>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -127,6 +127,10 @@ export const SETTINGS_LABEL_DATA = {
         label: "FSRS Params",
         help: "Specifies advanced parameters for the FSRS review algorithm.",
     },
+    gradingMethod: {
+        label: "Grading Method",
+        help: "Whether the system will grade the cards automatically or let the user manually grade them.",
+    },
     
     zhIsColorBasedOnTone: {
         label: "Color Characters Based On Their Tone",

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -22,6 +22,10 @@ export interface CharacterWriterData {
 
 export interface CharacterWriterConfig {
     isFirstTime: boolean;
+    isWarmUp: boolean;
+    warmUpCount: number | undefined;
+    warmUpMaxCount: number;
+    isShowOutline: boolean;
     lang: 'zh' | 'yue';
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,7 +59,7 @@
                 {app.getScheduledReviewCardsCount(info.id) || ''}
             </span>
             <span class="deck-count-new" title="new">
-                {app.getScheduledNewCardsCount(info.id) || ''}
+                {app.getScheduledNewOrWarmUpCardsCount(info.id) || ''}
             </span>
             <span class="deck-count-previously-studied" title="previously studied">
                 {app.getScheduledPreviouslyStudiedCardsCount(info.id) || ''}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,7 +29,7 @@
 <TopBar title="WenBun (beta)"></TopBar>
 <div class="main-container">
     <div class="top-container">
-        <a class="a-button" style="background-color: #F0E68C;" href="{base}/about/">Changelog</a>
+        <a class="a-button" style="background-color: #A0D0F0;" href="{base}/about/">Changelog</a>
         <a class="a-button" href="{base}/deck-browser/">Add New Deck</a>
     </div>
     <div class="hr"></div>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -18,6 +18,23 @@
     <div class="changelog-container">
         Change log
 
+        <h4>v0.5.0 (2025-08-09)</h4>
+        <div class="note">
+            It is advised for users to click "reset to default settings" in the settings. Or, if setting to auto grading mode, it's advised to disable short-term scheduling in FSRS settings.
+        </div>
+        <ul>
+            <li>Implement auto-grading for reviews</li>
+            <div class="note">
+                The grade can be overridden by clicking on the grade.<br>
+                "Easy" will not appear as an automatic grade.<br>
+                The parameters for auto-grading may change in the future.
+            </div>
+            <li>Add warm-up mode for new cards</li>
+            <li>Play audio only once in the new card view</li>
+            <li>Fix due-date filtering for review and learning/relearning cards</li>
+            <li>Various UI/UX improvements and bug fixes</li>
+        </ul>
+
         <h4>v0.4.0 (2025-08-06)</h4>
         <ul>
             <li>Add Extra Study feature with configurable study modes</li>

--- a/src/routes/deck/+page.svelte
+++ b/src/routes/deck/+page.svelte
@@ -160,7 +160,7 @@
                 </button>
                 {#if accordionState.get(group.label)}
                     {#if selectModeGroup == group.label}
-                        <div style="display: flex; flex-direction: row; justify-content: space-between; width: 100%">
+                        <div style="display: flex; flex-direction: row; justify-content: space-between; width: 100%; gap: 0.5em;">
                             <div class="group-buttons-container" style="align-items: flex-start;">
                                 <button class="button" onclick={() => stopSelectMode()}>
                                     <i class="fa-solid fa-xmark"></i>cancel selection
@@ -171,13 +171,13 @@
                             </div>
                             <div class="group-buttons-container" style="align-items: flex-end;">
                                 <button class="button" disabled={selections.size == 0} onclick={() => addPreviouslyStudiedMark()}>
-                                    <i class="fa-solid fa-book-open"></i>mark as <b>previously studied</b></button>
+                                    <i class="fa-solid fa-book-open"></i><span>mark as <b>previously studied</b></span></button>
                                 <button class="button" disabled={selections.size == 0} onclick={() => removePreviouslyStudiedMark()}>
-                                    <i class="fa-solid fa-book-open"></i>remove <b>previously studied</b> mark</button>
+                                    <i class="fa-solid fa-book-open"></i><span>remove <b>previously studied</b> mark</span></button>
                                 <button class="button" disabled={selections.size == 0} onclick={() => addIgnoredMark()}>
-                                    <i class="fa-solid fa-square-xmark"></i>mark as <b>ignored</b></button>
+                                    <i class="fa-solid fa-square-xmark"></i><span>mark as <b>ignored</b></span></button>
                                 <button class="button" disabled={selections.size == 0} onclick={() => removeIgnoredMark()}>
-                                    <i class="fa-solid fa-square-xmark"></i>remove <b>ignored</b> mark</button>
+                                    <i class="fa-solid fa-square-xmark"></i><span>remove <b>ignored</b> mark</span></button>
                             </div>
                         </div>
                     {/if}

--- a/src/routes/deck/+page.svelte
+++ b/src/routes/deck/+page.svelte
@@ -49,6 +49,7 @@
     function getCardStatusClass(deckId: string, cardId: number, app: App): string {
         switch (app.getWenbunCustomState(deckId, cardId) ?? WenBunCustomState.New) {
             case WenBunCustomState.New: return 'card-status-new';
+            case WenBunCustomState.WarmUp: return 'card-status-new';
             case WenBunCustomState.Learning: return 'card-status-learning';
             case WenBunCustomState.ReviewYoung: return 'card-status-review-young';
             case WenBunCustomState.ReviewMature: return 'card-status-review-mature';
@@ -135,6 +136,11 @@
         app = app;
     }
     
+    function statusToLabel(status: WenBunCustomState): string {
+        if (status === WenBunCustomState.WarmUp) return WenBunCustomState.New;
+        return status;
+    }
+    
 </script>
 
 <TopBar title="Deck" backUrl="{base}/"></TopBar>
@@ -206,7 +212,7 @@
                                 </div>
                                 <div class="card-details">
                                     <div class={`status ${getCardStatusClass(deckId, id, app)}`}>
-                                        {app.getWenbunCustomState(deckId, id) ?? WenBunCustomState.New}
+                                        {statusToLabel(app.getWenbunCustomState(deckId, id) ?? WenBunCustomState.New)}
                                     </div>
                                     <div class={`due ${getCardStatusClass(deckId, id, app)}`}>
                                         {app.getCardDueFormatted(deckId, id)}

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -58,7 +58,7 @@
             <table class="count-table"><tbody>
                 <tr class="row-count-new">
                     <td>New</td>
-                    <td class="count">{app.getScheduledNewCardsCount(deckInfo.id)}</td>
+                    <td class="count">{app.getScheduledNewOrWarmUpCardsCount(deckInfo.id)}</td>
                 </tr>
                 <tr class="row-count-learn-relearn">
                     <td>Learning</td>

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -180,30 +180,32 @@
         <div>You have done today's review.</div>
     {/if}
     {#if isPageReady && (currentCardId !== undefined) && !isDoneToday}
-        {#if data.isExtraStudy}
-            <div class="counter">
-                <span class="underlined">
-                    {#key currentCardId}
-                        {app.extraStudyHandler.getCardsCount() || ''}
-                    {/key}
-                </span>
-            </div>
-        {:else}
-            <div class="counter">
-                <span class="deck-count-learn-relearn" class:underlined={cardState === WenBunCustomState.Learning || cardState === WenBunCustomState.Relearning}>
-                    {app.getLearningRelearningCardsCount(deckId) || ''}
-                </span>
-                <span class="deck-count-review" class:underlined={cardState === WenBunCustomState.ReviewYoung || cardState === WenBunCustomState.ReviewMature}>
-                    {app.getScheduledReviewCardsCount(deckId) || ''}
-                </span>
-                <span class="deck-count-new" class:underlined={cardState === WenBunCustomState.New}>
-                    {app.getScheduledNewOrWarmUpCardsCount(deckId) || ''}
-                </span>
-                <span class="deck-count-previously-studied" class:underlined={cardState === WenBunCustomState.PreviouslyStudied}>
-                    {app.getScheduledPreviouslyStudiedCardsCount(deckId) || ''}
-                </span>
-            </div>
-        {/if}
+        {#key _changeCounter}
+            {#if data.isExtraStudy}
+                <div class="counter">
+                    <span class="underlined">
+                        {#key currentCardId}
+                            {app.extraStudyHandler.getCardsCount() || ''}
+                        {/key}
+                    </span>
+                </div>
+            {:else}
+                <div class="counter">
+                    <span class="deck-count-learn-relearn" class:underlined={cardState === WenBunCustomState.Learning || cardState === WenBunCustomState.Relearning}>
+                        {app.getLearningRelearningCardsCount(deckId) || ''}
+                    </span>
+                    <span class="deck-count-review" class:underlined={cardState === WenBunCustomState.ReviewYoung || cardState === WenBunCustomState.ReviewMature}>
+                        {app.getScheduledReviewCardsCount(deckId) || ''}
+                    </span>
+                    <span class="deck-count-new" class:underlined={cardState === WenBunCustomState.New}>
+                        {app.getScheduledNewOrWarmUpCardsCount(deckId) || ''}
+                    </span>
+                    <span class="deck-count-previously-studied" class:underlined={cardState === WenBunCustomState.PreviouslyStudied}>
+                        {app.getScheduledPreviouslyStudiedCardsCount(deckId) || ''}
+                    </span>
+                </div>
+            {/if}
+        {/key}
         <div class="character-writer-container">
             {#key [currentCardId, isNewCardInteractedWith, isCardChanged]}
                 <CharacterWriter 

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -21,6 +21,14 @@
     let cardIds = JSON.parse(decodeURIComponent(cardIdsStr));
     let title = data.isExtraStudy ? 'Extra Study' : 'Review';
     
+    type ReviewButton = {
+    	label: string;
+    	sublabel?: string;
+    	className?: string;
+    	onclick?: () => void;
+    	isComplete?: boolean;
+    };
+    
     let isPageReady = false;
     let app = new App();
     onMount(async () => {
@@ -185,112 +193,74 @@
             {/key}
         </div>
         {#if isFirstTime}
-            <div class="bottom-container" in:fly={inFlyParam} out:fade={outFadeParam}>
-                <div class="review-button-container">
-                    <button 
-                        class="review-button is-complete review-button-fail"
-                        onclick={() => ignoreCard()}
-                    >
-                        <div class="review-button-inner">
-                            <div class="review-time">(Don't Learn)</div>
-                            <div class="review-label">Ignore</div>
-                        </div>
-                    </button>
-                    <div class="review-button"><div class="review-time">&nbsp;</div><div class="review-label">&nbsp;</div></div>
-                    <div class="review-button"><div class="review-time">&nbsp;</div><div class="review-label">&nbsp;</div></div>
-                    <button 
-                        class="review-button is-complete review-button-easy"
-                        onclick={() => onNewCardInteracted()}
-                    >
-                        <div class="review-button-inner">
-                            <div class="review-time">&nbsp;</div>
-                            <div class="review-label">Learn</div>
-                        </div>
-                    </button>
-                </div>
-            </div>
+            {@render ReviewButtons([
+          		{ label: "Ignore", sublabel: "(Don't Learn)", className: "review-button-fail", isComplete: true, 
+                    onclick: () => ignoreCard() },
+          		{ label: "" },
+          		{ label: "" },
+          		{ label: "Learn", className: "review-button-easy", isComplete: true,
+                    onclick: () => onLearnNewCard() }
+           	])}
         {:else if data.isExtraStudy}
-            <div class="bottom-container" in:fly={inFlyParam} out:fade={outFadeParam}>
-                <div class="review-button-container">
-                    <button 
-                        class="review-button is-complete review-button-fail"
-                        class:is-complete={isComplete}
-                        onclick={() => extraStudyAgain()}
-                    >
-                        <div class="review-button-inner">
-                            <div class="review-time">(Put Back)</div>
-                            <div class="review-label">Again</div>
-                        </div>
-                    </button>
-                    <div class="review-button"><div class="review-time">&nbsp;</div><div class="review-label">&nbsp;</div></div>
-                    <div class="review-button"><div class="review-time">&nbsp;</div><div class="review-label">&nbsp;</div></div>
-                    <button 
-                        class="review-button is-complete review-button-easy"
-                        class:is-complete={isComplete}
-                        onclick={() => extraStudyGood()}
-                    >
-                        <div class="review-button-inner">
-                            <div class="review-time">&nbsp;</div>
-                            <div class="review-label">Good</div>
-                        </div>
-                    </button>
-                </div>
-            </div>
+           	{@render ReviewButtons([
+          		{ label: "Again", sublabel: "(Put Back)", className: "review-button-fail", isComplete, 
+                    onclick: () => extraStudyAgain() },
+          		{ label: "" },
+          		{ label: "" },
+          		{ label: "Good", className: "review-button-easy",  isComplete,
+                    onclick: () => extraStudyGood() }
+           	])}
         {:else if isAutoGrading && !isRequestManualGrade}
-            <div class="bottom-container" in:fly={inFlyParam} out:fade={outFadeParam}>
-                <div class="review-button-container">
-                    <div class="review-button"><div class="review-time">&nbsp;</div><div class="review-label">&nbsp;</div></div>
-                    <div class="review-button"><div class="review-time">&nbsp;</div><div class="review-label">&nbsp;</div></div>
-                    <div class="review-button"><div class="review-time">&nbsp;</div><div class="review-label">&nbsp;</div></div>
-                    <button 
-                        class="review-button is-complete review-button-easy"
-                        class:is-complete={isComplete}
-                        onclick={() => acceptAutoGrade()}
-                    >
-                        <div class="review-button-inner">
-                            <div class="review-time">&nbsp;</div>
-                            <div class="review-label">Next</div>
-                        </div>
-                    </button>
-                </div>
-            </div>
+           	{@render ReviewButtons([
+                { label: "" },
+          		{ label: "" },
+          		{ label: "" },
+          		{ label: "Next", className: "review-button-easy",  isComplete,
+                    onclick: () => acceptAutoGrade() }
+           	])}
         {:else if isAutoGrading && isRequestManualGrade}
-            <div class="bottom-container" in:fly={inFlyParam} out:fade={outFadeParam}>
-                <div class="review-button-container pulsing">
-                    {#each reviewButtonsLabel as label, i}
-                        <button 
-                            class={`review-button ${getReviewButtonClass(i+1)}`} 
-                            class:is-complete={isComplete}
-                            onclick={() => onManualChangeToAutoGrade(i+1)}
-                        >
-                            <div class="review-button-inner">
-                                <div class="review-time">{scheduledTimeStr[(i+1) as FSRS.Grade]}</div>
-                                <div class="review-label">{label}</div>
-                           </div>
-                        </button>
-                    {/each}
-                </div>
-            </div>
+           	{@render ReviewButtons(
+          		reviewButtonsLabel.map((label, i) => ({
+         			label,
+         			sublabel: scheduledTimeStr[(i+1) as FSRS.Grade],
+         			className: getReviewButtonClass(i+1),
+                    isComplete,
+         			onclick: () => onManualChangeToAutoGrade(i+1)
+          		})),
+                "pulsing"
+           	)}
         {:else}
-            <div class="bottom-container" in:fly={inFlyParam} out:fade={outFadeParam}>
-                <div class="review-button-container">
-                    {#each reviewButtonsLabel as label, i}
-                        <button 
-                            class={`review-button ${getReviewButtonClass(i+1)}`} 
-                            class:is-complete={isComplete}
-                            onclick={() => onReviewButtonClick(i+1)}
-                        >
-                            <div class="review-button-inner">
-                                <div class="review-time">{scheduledTimeStr[(i+1) as FSRS.Grade]}</div>
-                                <div class="review-label">{label}</div>
-                           </div>
-                        </button>
-                    {/each}
-                </div>
-            </div>
+           	{@render ReviewButtons(
+          		reviewButtonsLabel.map((label, i) => ({
+         			label,
+         			sublabel: scheduledTimeStr[(i+1) as FSRS.Grade],
+         			className: getReviewButtonClass(i+1),
+                    isComplete,
+         			onclick: () => onReviewButtonClick(i+1)
+          		}))
+           	)}
         {/if}
     {/if}
 </div>
+
+{#snippet ReviewButtons(buttons: ReviewButton[], extraClass = "")}
+	<div class="bottom-container" in:fly={inFlyParam} out:fade={outFadeParam}>
+		<div class={`review-button-container ${extraClass}`}>
+			{#each buttons as b}
+				<button
+					class={`review-button ${b.className || ""}`}
+					class:is-complete={b.isComplete}
+					onclick={b.onclick}
+				>
+					<div class="review-button-inner">
+						<div class="review-time">{b.sublabel || '\u00A0'}</div>
+						<div class="review-label">{b.label || '\u00A0'}</div>
+					</div>
+				</button>
+			{/each}
+		</div>
+	</div>
+{/snippet}
 
 <style>
     .container {

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -29,6 +29,7 @@
     	isComplete?: boolean;
     };
     
+    let autoReviewData: AutoReviewData;
     let isPageReady = false;
     let app = new App();
     onMount(async () => {
@@ -151,6 +152,7 @@
     }
     
     async function acceptAutoGrade() {
+        app.storeAutoGradeLog(autoReviewData.correctStrokeCount, autoReviewData.incorrectStrokeCount, autoGrade!);
         app.rateCard(deckId, currentCardId!, autoGrade!);
         await app.save();
         nextCard();
@@ -215,6 +217,7 @@
                     bind:isRequestManualGrade={isRequestManualGrade}
                     cardConfig={getCardConfig(currentCardId)}
                     autoGrade={autoGrade}
+                    bind:autoReviewData={autoReviewData}
                 />
             {/key}
         </div>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -35,6 +35,14 @@
         config = _.cloneDeep(initialConfig);
     }
     
+    async function resetConfigToDefault() {
+        const confirm = window.confirm("Are you sure you want to reset to the default settings?");
+        if (!confirm) return;
+        await app.resetConfigToDefault();
+        config = _.cloneDeep(app.getConfig());
+        initialConfig = _.cloneDeep(config);
+    }
+    
     async function resetDebugProfile(): Promise<void> {
         const confirm = window.confirm("Are you sure you want to reset to the debug profile?");
         if (!confirm) return;
@@ -130,7 +138,7 @@
                         To manually export the profile data, copy the text above and store it somewhere safe.<br>
                         To manually import the profile data, paste the text into the textbox and click the import button.
                     </div>
-                    <button class="button" onclick={() => resetDebugProfile()}>Reset Debug Profile</button>
+                    <!-- <button class="button" onclick={() => resetDebugProfile()}>Reset Debug Profile</button> -->
                 {/if}
                 <button class="button" onclick={() => isShowProfileTextbox = !isShowProfileTextbox}>
                     manual import/export
@@ -259,6 +267,12 @@
                 <SettingsItem key="zhToneNeutral">
                     <input type="color" bind:value={config.zh.toneColors[4]}>
                 </SettingsItem>
+            </div>
+        </div>
+        
+        <div class="settings-section">
+            <div class="section-container">
+                <button class="button" onclick={() => resetConfigToDefault()}>Reset to Default Settings</button>
             </div>
         </div>
         

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -149,6 +149,12 @@
         <div class="settings-section">
             <div class="section-title">Learning</div>
             <div class="section-container">
+                <SettingsItem key="gradingMethod">
+                    <select bind:value={config.gradingMethod}>
+                        <option value="auto">auto</option>
+                        <option value="manual">manual</option>
+                    </select>
+                </SettingsItem>
                 <SettingsItem key="newCardPerDay">
                     <input type="number" bind:value={config.newCardPerDay}>
                 </SettingsItem>


### PR DESCRIPTION
v0.5.0 (2025-08-09)
It is advised for users to click "reset to default settings" in the settings. Or, if setting to auto grading mode, it's advised to disable short-term scheduling in FSRS settings.
Implement auto-grading for reviews
The grade can be overridden by clicking on the grade.
"Easy" will not appear as an automatic grade.
The parameters for auto-grading may change in the future.
Add warm-up mode for new cards
Play audio only once in the new card view
Fix due-date filtering for review and learning/relearning cards
Various UI/UX improvements and bug fixes