### PR TITLE
Fix more parsing bugs of DuChinese CSV exports

### DIFF
--- a/src/lib/customDeck.ts
+++ b/src/lib/customDeck.ts
@@ -165,6 +165,10 @@ export class CustomDeckParser {
         word = word.replaceAll("》", "");
         word = word.replaceAll("﹏", "");
         word = word.replaceAll("·", "");
+        // Remove any extended ASCII character.
+        // Not fail safe, but good enough to remove all
+        // English mixed in with Chinese.
+        word = word.replaceAll(/[\x00-\xff]/g, "");
 
         return word;
     }

--- a/src/lib/customDeck.ts
+++ b/src/lib/customDeck.ts
@@ -102,10 +102,26 @@ export class CustomDeckParser {
             cells.push(current);
             return cells;
         };
+        let input_nl_normalized = input
+            .replace(/\r/gm, "")
+            .replace(/\n+/gm, "\n");
 
-        const rows = input
+        // Replace any and all new lines enclosed in "..." with a ';'
+        let one_line_entries = "";
+        let q = 0;
+        for (let i = 0; i < input_nl_normalized.length; i++) {
+            if (input_nl_normalized.at(i) == '"') {
+                q += 1;
+            } else if (input_nl_normalized.at(i) == '\n' && q % 2 == 1) {
+                // Skip new line within ".."
+                one_line_entries += " ; ";
+                continue;
+            }
+            one_line_entries += input_nl_normalized.at(i);
+        }
+
+        const rows = one_line_entries
             .split("\n")
-            .map((line) => line.replace(/\r$/, ""))
             .filter(w => w.trim() !== '' && !w.startsWith("#"))
             .slice(param.ignoreHeader ? 1 : 0)
             .map(parseLine);


### PR DESCRIPTION
Fixes more parsing issues with DuChinese exported CSV files.

CSV can contain newlines in strings enclosed in `""`. This PR replaces those new lines with `;`.

Additionally, it removes all extended ASCII characters from the Chinese character field. So Hanzi Writer doesn't fail if there are any.

Test data:

Test with default settings and columns 5, 7, 8.

```csv
# Exported from Du Chinese
Simplified,Traditional,Pinyin,Meaning,Simplified sentence,Traditional sentence,Sentence pinyin,Sentence translation
冬天,冬天,dōng tiān,winter,保罗：春天、夏天、秋天和冬天。,保羅：春天、夏天、秋天和冬天。,bǎo luó chūn tiān xià tiān qiū tiān hé dōng tiān,"Paul: Spring, summer, autumn, and winter."
秋天,秋天,qiū tiān,"autumn



fall",保罗：春天、夏天、秋天和冬天。,保羅：春天、夏天、秋天和冬天。,bǎo luó chūn tiān xià tiān qiū tiān hé dōng tiān,"Paul: Spring, summer, autumn, and winter."

怎么样,怎麼樣,zěn me yàng,"how
how about
what",高天：电影院很远，我和你一起去，你坐我的车，怎么样？,高天：電影院很遠，我和你一起去，你坐我的車，怎麼樣？,gāo tiān diàn yǐng yuàn hěn yuǎn wǒ hé nǐ yì qǐ qù nǐ zuò wǒ de chē zěn me yàng,Gao Tian: The movie theater is very far. I’ll go with you. You can take a ride in my car. How about that?
夏天,夏天,xià tiān,summer,保罗：春天、夏天、秋天和冬天。,保羅：春天、夏天、秋天和冬天。,bǎo luó chūn tiān xià tiān qiū tiān hé dōng tiān,"Paul: Spring, summer, autumn, and winter."
春天,春天,chūn tiān,spring (season),保罗：春天、夏天、秋天和冬天。,保羅：春天、夏天、秋天和冬天。,bǎo luó chūn tiān xià tiān qiū tiān hé dōng tiān,"Paul: Spring, summer, autumn, and winter."
```

Are there any other ways of testing for this App btw?